### PR TITLE
Fixed precision zero string printing and added tests for it

### DIFF
--- a/dev/VisualStudio/main.c
+++ b/dev/VisualStudio/main.c
@@ -249,6 +249,8 @@ main(void) {
     printf_run(NULL, "%.4.2s", "123456");
     printf_run(NULL, "%.*s", 3, "123456");
     printf_run(NULL, "%.3s", "");
+    printf_run(NULL, "%.0s", "Shouldn't print");
+    printf_run(NULL, "%.*s", 0, "Also shouldn't print");
     printf_run(NULL, "%yunknown", "");
 
     /* Alternate form */

--- a/lwprintf/src/lwprintf/lwprintf.c
+++ b/lwprintf/src/lwprintf/lwprintf.c
@@ -389,9 +389,6 @@ prv_out_str_raw(lwprintf_int_t* p, const char* buff, size_t buff_size) {
 static int
 prv_out_str(lwprintf_int_t* p, const char* buff, size_t buff_size) {
     /* Output string */
-    if (buff_size == 0) {
-        buff_size = strlen(buff);
-    }
     prv_out_str_before(p, buff_size);           /* Implement pre-format */
     prv_out_str_raw(p, buff, buff_size);        /* Print actual string */
     prv_out_str_after(p, buff_size);            /* Implement post-format */


### PR DESCRIPTION
The C standard says that the precision field for a string sets the maximum number of bytes to print. This PR addresses the check for a buffer size of zero in prv_out_str() that breaks this guarantee. While it may seem nonsensical to have this behavior, I found this issue when I passed zero into the first field of "%.*s" and it printed the buffer passed in the second field. There are some cases where this sort of behavior may be helpful for strings terminated by non-null characters.

Please check the that the tests pass/fail as expected.