### PR TITLE
Add test for string longer than output buffer size

### DIFF
--- a/dev/VisualStudio/main.c
+++ b/dev/VisualStudio/main.c
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include "windows.h"
 
+#define TEST_BUF_SIZE (255)
+
 typedef struct {
     char* format;                   /*!< Input format */
     char* input_data;               /*!< Input parameters */
@@ -64,7 +66,7 @@ printf_run_fn(const char* expected, const char* fmt, ...) {
     test_data_t* test;
     
     /* Temporary strings array */
-    char b1[255] = { 0 }, b2[sizeof(b1)] = { 0 };
+    char b1[TEST_BUF_SIZE] = { 0 }, b2[sizeof(b1)] = { 0 };
     int l1, l2;
 
     /* Set variables to non-0 values */
@@ -258,6 +260,11 @@ main(void) {
     printf_run(NULL, "%.*s", 3, "123456");
     printf_run(NULL, "%.3s", "");
     printf_run(NULL, "%yunknown", "");
+
+    /* Source string which exceeds output buffer size */
+    char c[TEST_BUF_SIZE+10];
+    memset(c, 0x5a5a5a5a, sizeof(c));
+    printf_run(NULL, "%s", c);
 
     /* Alternate form */
     printf_run(NULL, "%#2X", 123);


### PR DESCRIPTION
On Windows, this is one of those situations where the MSVC library function exhibits non-standard behavior, requiring callers to trap the return rather than just providing safe, standards-compliant behavior by default. However, lwprintf's behavior is compliant and as expected.

From §7.19.6.5¶2 of the [C standard reference I use](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf):

> The snprintf function is equivalent to fprintf, except that the output is written into
an array (specified by argument s) rather than to a stream. If n is zero, nothing is written,
and s may be a null pointer. Otherwise, output characters beyond the n-1st are
discarded rather than being written to the array, and a null character is written at the end
of the characters actually written into the array. If copying takes place between objects
that overlap, the behavior is undefined.