### PR TITLE
Fix building v1.0.4 with RTOS and without manual protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Develop
 
+- Fix building the library with `LWPRINTF_CFG_OS=1` and `LWPRINTF_CFG_OS_MANUAL_PROTECT=0` options
+
 ## v1.0.4
 
 - Fix calculation for NULL terminated string and precision with 0 as an input

--- a/lwprintf/src/lwprintf/lwprintf.c
+++ b/lwprintf/src/lwprintf/lwprintf.c
@@ -838,7 +838,7 @@ prv_format(lwprintf_int_t* lwi, va_list arg) {
     const char* fmt = lwi->fmt;
 
 #if LWPRINTF_CFG_OS && !LWPRINTF_CFG_OS_MANUAL_PROTECT
-    if (IS_PRINT_MODE(p) &&                                  /* OS protection only for print */
+    if (IS_PRINT_MODE(lwi) &&                                /* OS protection only for print */
         (!lwprintf_sys_mutex_isvalid(&lwi->lwobj->mutex)     /* Invalid mutex handle */
          || !lwprintf_sys_mutex_wait(&lwi->lwobj->mutex))) { /* Cannot acquire mutex */
         return 0;
@@ -1112,7 +1112,7 @@ prv_format(lwprintf_int_t* lwi, va_list arg) {
     }
     lwi->out_fn(lwi, '\0'); /* Output last zero number */
 #if LWPRINTF_CFG_OS && !LWPRINTF_CFG_OS_MANUAL_PROTECT
-    if (IS_PRINT_MODE(p)) { /* Mutex only for print operation */
+    if (IS_PRINT_MODE(lwi)) { /* Mutex only for print operation */
         lwprintf_sys_mutex_release(&lwi->lwobj->mutex);
     }
 #endif /* LWPRINTF_CFG_OS && !LWPRINTF_CFG_OS_MANUAL_PROTECT */


### PR DESCRIPTION
Hi! When I updated the library to version `v1.0.4`, my project began to build with errors...

In my project the library is built with options

```
LWPRINTF_CFG_OS=1
LWPRINTF_CFG_OS_MANUAL_PROTECT=0
```

The problem turned out to be just a typo in code