### PR TITLE
fix float fmt error

### DIFF
--- a/lwprintf/src/lwprintf/lwprintf.c
+++ b/lwprintf/src/lwprintf/lwprintf.c
@@ -857,12 +857,14 @@ prv_format(lwprintf_int_t* lwi, va_list arg) {
             lwi->m.flags.uc = 1;
         }
         switch (*fmt) {
+#if LWPRINTF_CFG_SUPPORT_TYPE_FLOAT
             case 'a':
             case 'A':
                 /* Double in hexadecimal notation */
                 (void)va_arg(arg, double);      /* Read argument to ignore it and move to next one */
                 prv_out_str_raw(lwi, "NaN", 3); /* Print string */
                 break;
+#endif /* LWPRINTF_CFG_SUPPORT_TYPE_FLOAT */
             case 'c': lwi->out_fn(lwi, (char)va_arg(arg, int)); break;
 #if LWPRINTF_CFG_SUPPORT_TYPE_INT
             case 'd':


### PR DESCRIPTION
According to the documentation at https://man7.org/linux/man-pages/man3/printf.3.html, the %a and %A specifiers are used for floating-point formatting; therefore, we need to add the LWPRINTF_CFG_SUPPORT_TYPE_FLOAT configuration option.