### PR TITLE
fix: correct num_buf sizing and ll binary truncation in prv_longest_unsigned_int_to_str

### DIFF
--- a/lwprintf/src/lwprintf/lwprintf.c
+++ b/lwprintf/src/lwprintf/lwprintf.c
@@ -358,8 +358,8 @@ prv_out_str(lwprintf_int_t* lwi, const char* buff, size_t buff_size) {
  */
 static int
 prv_longest_unsigned_int_to_str(lwprintf_int_t* lwi, uint_maxtype_t num) {
-    /* Start with digits length, support binary with int, that is 32-bits maximum width */
-    char num_buf[33], *num_buf_ptr = &num_buf[sizeof(num_buf)];
+    /* Size buffer for the widest supported type (binary base needs one char per bit) */
+    char num_buf[8 * sizeof(uint_maxtype_t) + 1], *num_buf_ptr = &num_buf[sizeof(num_buf)];
     char adder_ch = (lwi->m.flags.uc ? 'A' : 'a') - 10;
     size_t len = 0;
 
@@ -906,7 +906,7 @@ prv_format(lwprintf_int_t* lwi, va_list arg) {
                     prv_longest_unsigned_int_to_str(lwi, (uint_maxtype_t)va_arg(arg, size_t));
                 } else if (lwi->m.flags.umax_t) {
                     prv_longest_unsigned_int_to_str(lwi, (uint_maxtype_t)va_arg(arg, uintmax_t));
-                } else if (lwi->m.flags.longlong == 0 || lwi->m.base == 2) {
+                } else if (lwi->m.flags.longlong == 0) {
                     uint_maxtype_t v = va_arg(arg, unsigned int);
                     switch (lwi->m.flags.char_short) {
                         case 2: v = (uint_maxtype_t)((unsigned char)v); break;

--- a/tests/test.c
+++ b/tests/test.c
@@ -215,6 +215,29 @@ test_printf(void) {
     do_test(buffer, sizeof(buffer), "0B110", 5, "%#B", 6);
     do_test(buffer, sizeof(buffer), "0b110", 5, "%#b", 6);
 
+    /*
+     * Regression: full-width binary output must not underflow num_buf (previously fixed
+     * 33-byte buffer regardless of type width) nor silently truncate a "ll"-qualified
+     * argument to 32-bit. Expected strings are sized off the real type width so the test
+     * stays correct on both 32-bit and 64-bit builds.
+     */
+    {
+        char full_ones[8 * sizeof(unsigned long long) + 1];
+
+        memset(full_ones, '1', 8 * sizeof(size_t));
+        full_ones[8 * sizeof(size_t)] = '\0';
+        do_test(buffer, sizeof(buffer), full_ones, (int)(8 * sizeof(size_t)), "%zb", (size_t)-1);
+
+        memset(full_ones, '1', 8 * sizeof(uintmax_t));
+        full_ones[8 * sizeof(uintmax_t)] = '\0';
+        do_test(buffer, sizeof(buffer), full_ones, (int)(8 * sizeof(uintmax_t)), "%jb", (uintmax_t)-1);
+
+        memset(full_ones, '1', 8 * sizeof(unsigned long long));
+        full_ones[8 * sizeof(unsigned long long)] = '\0';
+        do_test(buffer, sizeof(buffer), full_ones, (int)(8 * sizeof(unsigned long long)), "%llb",
+                (unsigned long long)-1);
+    }
+
     /* Hex data */
     uint8_t my_arr[] = {0x01, 0x02, 0xB5, 0xC6, 0xD7};
     do_test(buffer, sizeof(buffer), "0102B5C6D7", 10, "%5K", my_arr);


### PR DESCRIPTION
## Problem

`prv_longest_unsigned_int_to_str()` declares:

```c
char num_buf[33], *num_buf_ptr = &num_buf[sizeof(num_buf)];
```

sized for a 32-bit value in binary (32 digits + nul), regardless of the actually configured widest unsigned integer type. With `LWPRINTF_CFG_SUPPORT_LONG_LONG` enabled (the default), `uint_maxtype_t` is `unsigned long long` (64-bit). A full-width value formatted in base 2 via `%zb` or `%jb` writes 64 digits backward into this 33-byte buffer, underflowing the stack buffer by 32 bytes.

Separately, in the `%b/%B/%o/%u/%x/%X` handling:

```c
} else if (lwi->m.flags.longlong == 0 || lwi->m.base == 2) {
    uint_maxtype_t v = va_arg(arg, unsigned int);
    ...
```

the `|| lwi->m.base == 2` unconditionally forces base-2 (`%b`/`%B`) conversions onto the 32-bit `unsigned int` path even when the `ll` length modifier is present, so `%llb` silently reads only `sizeof(unsigned int)` bytes from `va_arg` and truncates the caller's 64-bit argument to its low 32 bits. Every other base (`o`/`u`/`x`/`X`) already reads the correct width for `ll` — only binary was special-cased incorrectly.

## Fix

- Size `num_buf` from `sizeof(uint_maxtype_t)` instead of a hardcoded `33`.
- Drop the erroneous `|| lwi->m.base == 2` so `%llb` takes the same `longlong`-aware path already used by `o`/`u`/`x`/`X`.

Both changes are minimal and don't touch any call sites or public API.

## Testing

Added regression tests for `%zb`/`%jb`/`%llb` with an all-ones full-width value, sized against `sizeof(size_t)`/`sizeof(uintmax_t)`/`sizeof(unsigned long long)` at compile time so they hold on both 32-bit and 64-bit builds (matching this repo's own CI, which builds Win32).

Verified locally with MinGW GCC 8.1.0:
- Against the original (unmodified) source, the 3 new tests fail: `%zb`/`%jb` produce a 3-character garbage string instead of the expected all-`1`s string (stack corruption from the buffer underflow — reproducible on unoptimized builds; behavior is undefined so it can vary with optimization level), and `%llb` produces exactly 32 `1`s instead of 64 (confirming the truncation).
- After the fix, all three new tests pass and the buffer bound is respected (verified with an added pointer-arithmetic diagnostic, since removed).
- Full existing test suite: 148/151 pre-existing tests still pass; the same 3 pre-existing failures (lines 202-204, `%p` pointer-width assumptions) occur identically before and after this change and are unrelated to this fix.